### PR TITLE
DBW will execute a minimum brake when:

### DIFF
--- a/ros/launch/styx_non_dbw.launch
+++ b/ros/launch/styx_non_dbw.launch
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<launch>
+    <!--Waypoint Loader -->
+    <include file="$(find waypoint_loader)/launch/waypoint_loader.launch"/>
+
+    <!--Waypoint Follower Node -->
+    <include file="$(find waypoint_follower)/launch/pure_pursuit.launch"/>
+
+    <!--Waypoint Updater Node -->
+    <include file="$(find waypoint_updater)/launch/waypoint_updater.launch"/>
+
+    <!--Traffic Light Detector Node -->
+    <include file="$(find tl_detector)/launch/tl_detector.launch"/>
+
+    <!--Traffic Light Locations and Camera Config -->
+    <param name="traffic_light_config" textfile="$(find tl_detector)/sim_traffic_light_config.yaml" />
+</launch>


### PR DESCRIPTION
1) dbw is first enabled
2) if twist commands are not received for 0.5 sec.

This will ensure the car stops while the pipeline initializes and receives the first image
or if doesn't receive waypoint updates.